### PR TITLE
Document new app_review_attachment_file feature

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -237,6 +237,15 @@ app_review_information(
 
 You can also provide these values by creating files in a `metadata/review_information/` directory. The file names must match the pattern `<key>.txt` (e.g. `first_name.txt`, `notes.txt` etc.). The contents of each file will be used as the value for the matching key. Values provided in the `Deliverfile` or `Fastfile` will be take priority over values from these files.
 
+##### app_review_attachment_file
+You can provide additional information to the app review team as a file attachment. As of this writing, Apple supports following file attachment formats: .pdf, .doc, .docx, .rtf, .pages, .xls, .xlsx, .numbers, .zip, .rar, .plist, .crash, .jpg, .png, .mp4, or .avi.
+
+Provide an empty string (i.e. "", not null) to remove the existing attachment file (if any) from the review information being edited.
+	
+```ruby-skip-tests
+app_review_attachment_file: "./readme.txt"
+```
+	
 ##### submission_information
 Must be a hash. This is used as the last step for the deployment process, where you define if you use third party content or use encryption. [A list of available options](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/tunes/app_submission.rb).
 


### PR DESCRIPTION
Modified per new feature krish722 has added in PR 14412.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I am proposing this change as a part of Krish722's PR 14412 to add an app_review_attachment_file feature to `deliver`.

### Description
This is a documentation-only change. No runtime testing was necessary.